### PR TITLE
added: support for audiences as regexp

### DIFF
--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -26,7 +26,7 @@ func (c Claims) Valid() error {
 	if err != nil {
 		return fmt.Errorf("Invalid audience %q: %v", c.Audience, err)
 	}
-	if !c.cfg.containsAudience(aud) {
+	if !c.cfg.matchesAudience(aud) {
 		return fmt.Errorf("Unexpected audience: %q", c.Audience)
 	}
 	return nil

--- a/jwt/config.go
+++ b/jwt/config.go
@@ -1,23 +1,22 @@
 package jwt
 
-import "errors"
+import (
+	"errors"
+	"net/url"
+	"regexp"
+)
 
 // Config specifies the parameters for which to perform validation of JWT
 // tokens in requests against.
 type Config struct {
-	PublicKeys map[string]PublicKey
-	Audiences  []*Audience
+	PublicKeys     map[string]PublicKey
+	MatchAudiences *regexp.Regexp
 }
 
 // Validate validates the Configuration.
 func (cfg *Config) Validate() error {
-	if len(cfg.Audiences) == 0 {
-		return errors.New("No audiences defined")
-	}
-	for _, aud := range cfg.Audiences {
-		if err := aud.Validate(); err != nil {
-			return err
-		}
+	if cfg.MatchAudiences == nil {
+		return errors.New("No audiences to match defined")
 	}
 	if len(cfg.PublicKeys) == 0 {
 		return errors.New("No public keys defined")
@@ -25,11 +24,6 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
-func (cfg *Config) containsAudience(aud *Audience) bool {
-	for _, aud2 := range cfg.Audiences {
-		if *aud == *aud2 {
-			return true
-		}
-	}
-	return false
+func (cfg *Config) matchesAudience(aud *Audience) bool {
+	return cfg.MatchAudiences.MatchString((*url.URL)(aud).String())
 }

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ func main() {
 		log.Fatal(err)
 	}
 
+	log.Printf("Matching audiences: %s\n", cfg.MatchAudiences)
+
 	http.HandleFunc("/auth", authHandler)
 	http.HandleFunc("/healthz", healthzHandler)
 


### PR DESCRIPTION
Support audiences as regexps too if they are enclosed in slashes like `/^https://example\.com:443$/`