### PR TITLE
Handle updated JWT header sent by Google

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -19,7 +18,7 @@ var (
 	cfg            = &jwt.Config{}
 	listenAddr     = flag.String("listen-addr", "0.0.0.0", "Listen address")
 	listenPort     = flag.String("listen-port", "", "Listen port (default: 80 for HTTP or 443 for HTTPS)")
-	audiences      = flag.String("audiences", "", "Comma-separated list of JWT Audiences (elements can be URLs like \"https://exammple.com:port\" or regular expressions like \"/^https://example\\.com:port$/\" if you enclose them in slashes)")
+	audiences      = flag.String("audiences", "", "Comma-separated list of JWT Audiences (elements can be paths like \"/projects/PROJECT_NUMBER/apps/PROJECT_ID\" or regular expressions like \"/^\\/projects\\/PROJECT_NUMBER/.*\" if you enclose them in slashes)")
 	publicKeysPath = flag.String("public-keys", "", "Path to public keys file (optional)")
 	tlsCertPath    = flag.String("tls-cert", "", "Path to TLS server's, intermediate's and CA's PEM certificate (optional)")
 	tlsKeyPath     = flag.String("tls-key", "", "Path to TLS server's PEM key file (optional)")
@@ -100,7 +99,7 @@ func parseRawAudience(audience string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Invalid audience %q (%v)", audience, err)
 	}
-	return fmt.Sprintf("^%s$", regexp.QuoteMeta((*url.URL)(aud).String())), nil
+	return fmt.Sprintf("^%s$", regexp.QuoteMeta((string)(*aud))), nil
 }
 
 func initPublicKeys(filePath string) error {

--- a/jwt/audience.go
+++ b/jwt/audience.go
@@ -1,79 +1,33 @@
 package jwt
 
 import (
-	"errors"
-	"fmt"
-	"net"
-	"net/url"
-	"strings"
 )
 
-// Audience must be the base URL from the request including protocol, domain,
-// and port if applicable for the domains you specify in your IAP proxy. For
-// example, https://example.com or https://foo.example.com:port.
-type Audience url.URL
+// From the IAP docs at https://cloud.google.com/iap/docs/signed-headers-howto:
+// Audience must be a string with the following values:
+// * App Engine: /projects/PROJECT_NUMBER/apps/PROJECT_ID
+// * Compute Engine and Container Engine: /projects/PROJECT_NUMBER/global/backendServices/SERVICE_ID
+type Audience string
 
-// NewAudience returns an Audience from a URL.
-func NewAudience(u *url.URL) *Audience {
+// NewAudience returns an Audience from a string.
+func NewAudience(u *string) *Audience {
 	return (*Audience)(u)
 }
 
 // Sanitize normalizes the structure of the Audience's URL and validates it.
 func (aud *Audience) Sanitize() error {
-	aud.Scheme = strings.ToLower(aud.Scheme)
-	var err error
-	var port string
-	host := aud.Host
-	if strings.LastIndex(host, ":") >= 0 {
-		host, port, err = net.SplitHostPort(host)
-		if err != nil {
-			return err
-		}
-	}
-	if len(port) == 0 {
-		defaultPort := "80"
-		if aud.Scheme == "https" {
-			defaultPort = "443"
-		}
-		aud.Host = net.JoinHostPort(host, defaultPort)
-	}
 	return aud.Validate()
 }
 
 // Validate performs error checking on the Audience's URL.
 func (aud *Audience) Validate() error {
-	if aud.Scheme != "http" && aud.Scheme != "https" {
-		return fmt.Errorf("Unexpected scheme: %s", aud.Scheme)
-	}
-	host, _, err := net.SplitHostPort(aud.Host)
-	if err != nil {
-		return err
-	}
-	if len(host) == 0 {
-		return errors.New("Host not specified")
-	}
-	if aud.User != nil {
-		return errors.New("Not expecting user")
-	}
-	if len(aud.Path) != 0 || len(aud.RawPath) != 0 {
-		return errors.New("Not expecting path")
-	}
-	if len(aud.RawQuery) != 0 {
-		return errors.New("Not expecting query")
-	}
-	if len(aud.Fragment) != 0 {
-		return errors.New("Not expecting fragment")
-	}
+	// TODO: Add actual validation
 	return nil
 }
 
-// ParseAudience parses an Audience from a URL string.
-func ParseAudience(rawURL string) (*Audience, error) {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, err
-	}
-	aud := NewAudience(u)
+// ParseAudience parses an Audience from a string.
+func ParseAudience(rawAudience string) (*Audience, error) {
+	aud := NewAudience(&rawAudience)
 	if err := aud.Sanitize(); err != nil {
 		return nil, err
 	}

--- a/jwt/config.go
+++ b/jwt/config.go
@@ -2,7 +2,6 @@ package jwt
 
 import (
 	"errors"
-	"net/url"
 	"regexp"
 )
 
@@ -25,5 +24,5 @@ func (cfg *Config) Validate() error {
 }
 
 func (cfg *Config) matchesAudience(aud *Audience) bool {
-	return cfg.MatchAudiences.MatchString((*url.URL)(aud).String())
+	return cfg.MatchAudiences.MatchString((string)(*aud))
 }

--- a/jwt/token.go
+++ b/jwt/token.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	tokenHeader    = "X-Goog-Authenticated-User-JWT"
+	tokenHeader    = "X-Goog-IAP-JWT-Assertion"
 	algorithm      = "ES256"
 	algorithmClaim = "alg"
 	keyIDClaim     = "kid"


### PR DESCRIPTION
Google is [changing the header name](https://cloud.google.com/iap/docs/release-notes#july_14_2017) containing the JWT from `X-Goog-Authenticated-User-JWT` to `X-Goog-IAP-JWT-Assertion`. According to a support email that doesn't appear to be online, the old header will no longer be sent as of November 15th, 2017.

The JWT sent in the new header also changes the value of `aud` within the token. It is no longer a URL, but [one of two values](https://cloud.google.com/iap/docs/signed-headers-howto) depending on the type of app:
* App Engine: `/projects/PROJECT_NUMBER/apps/PROJECT_ID`
* Compute Engine and Container Engine: `/projects/PROJECT_NUMBER/global/backendServices/SERVICE_ID`

This PR changes the header to the new value, and treats the audience as a simple string that can be matched against, instead of a URL.

Maybe a better path to go down would be configuring the project id / number / service id as individual configuration parameters? Though I like the original flexibility of using regular expressions.