### PR TITLE
Add headers in auth handler

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -29,6 +29,8 @@ func authHandler(res http.ResponseWriter, req *http.Request) {
 		Subject: claims.Subject,
 		Email:   claims.Email,
 	}
+	res.Header().Add("email", user.Email)
+	res.Header().Add("subject", user.Subject)
 	expiresAt := time.Unix(claims.ExpiresAt, 0).UTC()
 	log.Printf("Authenticated %q (token expires at %v)\n", user.Email, expiresAt)
 	res.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Return headers from the auth handler, so they can be propagated by the caller, e.g. by using the `auth_request_set` function in nginx.