### PR TITLE
Migrate to golang-jwt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/imkira/gcp-iap-auth
 go 1.16
 
 require (
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/namsral/flag v1.7.4-alpha
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/namsral/flag v1.7.4-alpha h1:Mo7Jb27IFSrW2WKmU55iw8A9UXagVyv5zcyjAmIFEQ4=
 github.com/namsral/flag v1.7.4-alpha/go.mod h1:OXldTctbM6SWH1K899kPZcf65KxJiD7MsceFUpB5yDo=

--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -3,7 +3,7 @@ package jwt
 import (
 	"fmt"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 )
 
 // Claims represents parsed JWT Token Claims.

--- a/jwt/request.go
+++ b/jwt/request.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 )
 
 // ValidateRequestClaims checks the validity of the claims in the request.

--- a/jwt/token.go
+++ b/jwt/token.go
@@ -3,7 +3,7 @@ package jwt
 import (
 	"fmt"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 const (


### PR DESCRIPTION
Migrates to github.com/golang-jwt/jwt as a drop-in replacement for github.com/dgrijalva/jwt-go because of a [security vulnerability](https://github.com/advisories/GHSA-w73w-5m7g-f7qc)